### PR TITLE
Remove use of fmt.Sprintf and fmt.Fprintf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REV:=$(shell git rev-parse HEAD)
 
-all: build test run
+all: build test bench run
 
 testdeps:
 	go get github.com/stretchr/testify/assert
@@ -14,6 +14,9 @@ build: dist
 
 test: testdeps
 	go test -v ./...
+
+bench: testdeps
+	go test -bench=. -v ./...
 
 run: build
 	dist/changelogger -h || true

--- a/changelog.go
+++ b/changelog.go
@@ -1,7 +1,6 @@
 package changelog
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"reflect"
@@ -77,11 +76,7 @@ type Subsection struct {
 // String returns the markdown representation of the subsection.
 func (s *Subsection) String() string {
 	if len(s.History) > 0 {
-		return fmt.Sprintf(
-			"### %s\n\n%s",
-			s.Name,
-			join(s.History, "\n"),
-		)
+		return "### " + s.Name + "\n\n" + join(s.History, "\n")
 	}
 	return ""
 }
@@ -106,17 +101,11 @@ type ChangeLine struct {
 // String returns the markdown representation of the ChangeLine.
 // E.g. "  * Added documentation. (#123)"
 func (l *ChangeLine) String() string {
-	if l.Reference == "" {
-		return fmt.Sprintf(
-			"  * %s",
-			l.Summary,
-		)
+	str := "  * " + l.Summary
+	if l.Reference != "" {
+		str += " (" + l.Reference + ")"
 	}
-	return fmt.Sprintf(
-		"  * %s (%s)",
-		l.Summary,
-		l.Reference,
-	)
+	return str
 }
 
 // join calls the .String() function of each element in the slice it's

--- a/changelogger/changelogger.go
+++ b/changelogger/changelogger.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -45,5 +44,7 @@ func main() {
 		writer = f
 		defer f.Close()
 	}
-	fmt.Fprintf(writer, "%s", history)
+	if _, err := writer.Write([]byte(history.String())); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/filefinder.go
+++ b/filefinder.go
@@ -1,9 +1,7 @@
 package changelog
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 	"regexp"
 )
 
@@ -17,8 +15,8 @@ var historyFilenameRegexp = regexp.MustCompile("(?i:(History|Changelog).m(ar)?k?
 func HistoryFilename() string {
 	infos, err := ioutil.ReadDir(".")
 	if err != nil {
-		fmt.Println("Problem finding your history file.")
-		os.Exit(1)
+		logFatal("Problem finding your history file.")
+		// System exit!
 	}
 	for _, info := range infos {
 		if isHistoryFile(info.Name()) {

--- a/parse.go
+++ b/parse.go
@@ -29,6 +29,10 @@ func logVerbose(args ...interface{}) {
 	}
 }
 
+func logFatal(format string, args ...interface{}) {
+	log.Fatalf(format, args...)
+}
+
 func matchLine(regexp *regexp.Regexp, line string) (matches []string, doesMatch bool) {
 	if regexp.MatchString(line) {
 		return regexp.FindStringSubmatch(line), true

--- a/testdata/History-rewritten.md
+++ b/testdata/History-rewritten.md
@@ -674,7 +674,7 @@
   * Allow custom markdown processors (#1872)
   * Provide support for the Rouge syntax highlighter (#1859)
   * Provide support for Sass (#1932)
-  * Provide a 300%!i(MISSING)mprovement when generating sites that use `Post#next` or `Post#previous` (#1983)
+  * Provide a 300% improvement when generating sites that use `Post#next` or `Post#previous` (#1983)
   * Provide support for CoffeeScript (#1991)
   * Replace Maruku with Kramdown as Default Markdown Processor (#1988)
   * Expose `site.static_files` to Liquid (#2075)
@@ -755,7 +755,7 @@
   * Only strip the drive name if it begins the string (#2175)
   * Remove default post with invalid date from site template (#2200)
   * Fix `Post#url` and `Page#url` escape (#1568)
-  * Strip newlines from the `{%!h(MISSING)ighlight %!}(MISSING)` block content (#1823)
+  * Strip newlines from the `{% highlight %}` block content (#1823)
   * Load in `rouge` only when it's been requested as the highlighter (#2189)
   * Convert input to string before XML escaping (`xml_escape` liquid filter) (#2244)
   * Modify configuration key for Collections and reset properly. (#2238)
@@ -1614,7 +1614,7 @@
 ## 0.5.5 / 2010-01-08
 
   * Bug Fixes
-  * Fix pagination %!b(MISSING)ug (#78)
+  * Fix pagination % 0 bug (#78)
   * Ensure all posts are processed first (#71)
   * After this point I will no longer be giving credit in the history; that is what the commit log is for.
 
@@ -1746,7 +1746,7 @@
 ## 0.1.6 / 2008-12-13
 
   * Major Features
-  * Include files in `_includes` with `{%!i(MISSING)nclude x.textile %!}(MISSING)`
+  * Include files in `_includes` with `{% include x.textile %}`
 
 ## 0.1.5 / 2008-12-12
 

--- a/testdata/changelog-string-complex.md
+++ b/testdata/changelog-string-complex.md
@@ -2,12 +2,12 @@
 
 ## 1.2.3 / 2022-10-10
 
-  * summary 2 (#2)
+  * summary 2 (https://example.com/subpage/%282%29)
   * summary 3 (#3)
 
 ## 3.2.1
 
-  * summary 4 (#4)
+  * summary 4 - https://example.com/subpage/%284%29 (#4)
 
 ### Subsection A
 


### PR DESCRIPTION
Also, added benchmarks for `*Changelog.String()`:

```text
goos: darwin
goarch: arm64
pkg: github.com/parkr/changelog
BenchmarkChangelogString_Simplest
BenchmarkChangelogString_Simplest-10    	 1000000	      1009 ns/op
BenchmarkChangelogString_Complex
BenchmarkChangelogString_Complex-10     	  256810	      4634 ns/op
```