### PR TITLE
Add support for [Unreleased] version

### DIFF
--- a/convenience.go
+++ b/convenience.go
@@ -9,10 +9,10 @@ import (
 // initialized except {{.Date}}.
 func NewVersion(versionNum string) *Version {
 	var sortOrder int
-	switch strings.TrimSpace(versionNum) {
+	switch strings.ToUpper(strings.TrimSpace(versionNum)) {
 	case "":
 		sortOrder = -1
-	case "HEAD":
+	case "HEAD", "[UNRELEASED]":
 		sortOrder = 0
 	default:
 		sortOrder = 1

--- a/parse.go
+++ b/parse.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	versionRegexp           = regexp.MustCompile(`##? (?i:(HEAD|v?\d+\.\d+(?:\.\d+)?))(?U:.*)(\d{4}-\d{2}-\d{2})?.?$`)
+	versionRegexp           = regexp.MustCompile(`##? (?i:(\[UNRELEASED\]|HEAD|v?\d+\.\d+(?:\.\d+)?))(?U:.*)(\d{4}-\d{2}-\d{2})?.?$`)
 	subheaderRegexp         = regexp.MustCompile(`### ([0-9A-Za-z_ ]+)`)
 	changeLineRegexp        = regexp.MustCompile(`[\*|\-] (.+)`)
 	changeLineRegexpWithRef = regexp.MustCompile(`[\*|\-] (.+)( \(((#[0-9]+)|(@?[[:word:]]+))\))`)

--- a/parse_test.go
+++ b/parse_test.go
@@ -20,6 +20,10 @@ var (
 			matched: []string{"# HEAD", "HEAD", ""},
 		},
 		{
+			text:    "# [Unreleased]",
+			matched: []string{"# [Unreleased]", "[Unreleased]", ""},
+		},
+		{
 			text:    "# 1.0.0",
 			matched: []string{"# 1.0.0", "1.0.0", ""},
 		},


### PR DESCRIPTION
I use an `[Unreleased]` version in my changelogs as described here: https://keepachangelog.com/en/1.0.0/. It's semantically equivalent to a `HEAD` version.