### PR TITLE
Support semver & keepachangelog format

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	versionRegexp           = regexp.MustCompile(`##? (?i:(\[UNRELEASED\]|HEAD|v?\d+\.\d+(?:\.\d+)?))(?U:.*)(\d{4}-\d{2}-\d{2})?.?$\z`)
+	versionRegexp           = regexp.MustCompile(`##? \[?(?i:(\[UNRELEASED\]|HEAD|v?\d+\.\d+(?:\.\d+)?(?:[-+][\w+\-.]+)?))\]?.*?(\d{4}-\d{2}-\d{2})?.?$\z`)
 	subheaderRegexp         = regexp.MustCompile(`### ([0-9A-Za-z_ ]+)\z`)
 	changeLineRegexp        = regexp.MustCompile(`[\*|\-] (.+)\z`)
 	changeLineRegexpWithRef = regexp.MustCompile(`[\*|\-] (.+)( \(((#[0-9]+)|(@?[[:word:]]+))\))\z`)

--- a/parse_test.go
+++ b/parse_test.go
@@ -87,6 +87,22 @@ var (
 			text:    " ## v0.6 (2015-02-30)",
 			matched: []string{"## v0.6 (2015-02-30)", "v0.6", "2015-02-30"},
 		},
+		{
+			text:    "## v0.6.0-beta",
+			matched: []string{"## v0.6.0-beta", "v0.6.0-beta", ""},
+		},
+		{
+			text:    "## v0.6.0-beta - 2015-02-30",
+			matched: []string{"## v0.6.0-beta - 2015-02-30", "v0.6.0-beta", "2015-02-30"},
+		},
+		{
+			text:    "## [v0.6.0-beta] - 2015-02-30",
+			matched: []string{"## [v0.6.0-beta] - 2015-02-30", "v0.6.0-beta", "2015-02-30"},
+		},
+		{
+			text:    "## [1.0.0-rc.1+build.1] - 2015-02-30",
+			matched: []string{"## [1.0.0-rc.1+build.1]", "1.0.0-rc.1+build.1", "2015-02-30"},
+		},
 	}
 	subheaders = []testRegexpOutput{
 		{


### PR DESCRIPTION
This PR adds support for some common formats.
- Support for [semver](https://semver.org) versions with prerelease/build information e.g. `1.0.0-alpha` or `1.0.0-rc.1+build.1`.
- Support for [keepachangelog.com](https://keepachangelog.com) format e.g. square brackets around version.